### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   Generate-Changelog:
     runs-on: ubuntu-latest

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ if (!await knex.schema.hasTable('db_table_versions')) {
 }
 // get request handler
 const handle = new Handle(modules)
-handle.init(modules, knex)
+await handle.init(modules, knex)
 
 // set up logging
 const log = new Log(config.logging)


### PR DESCRIPTION
Potential fix for [https://github.com/Keukeiland/KeukNet/security/code-scanning/1](https://github.com/Keukeiland/KeukNet/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the `Generate-Changelog` job. Based on the functionality of the `mikepenz/release-changelog-builder-action`, the job likely only needs `contents: read` to access repository content and generate a changelog. We will add this block to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
